### PR TITLE
Fix start date

### DIFF
--- a/jobs/refresh_tracker.py
+++ b/jobs/refresh_tracker.py
@@ -10,9 +10,6 @@ import numpy as np
 import pandas as pd
 from pygsheets import Spreadsheet, Worksheet
 
-TECH_TRACKER_SHEET = os.getenv("TECH_TRACKER_SHEETS_ID")
-HR_MOT_SHEET = os.getenv("HR_MOT_SHEETS_ID")
-GOOGLE_CREDENTIALS = os.getenv("CREDENTIALS_FILE")
 
 logger = logging.getLogger(__name__)
 

--- a/jobs/refresh_tracker.py
+++ b/jobs/refresh_tracker.py
@@ -1,11 +1,10 @@
 from datetime import date, datetime
 import logging
 import os
-from time import sleep
 from typing import Union
 from zoneinfo import ZoneInfo
 
-from gbq_connector import BigQueryClient, DbtClient
+from gbq_connector import BigQueryClient
 import numpy as np
 import pandas as pd
 from pygsheets import Spreadsheet, Worksheet
@@ -203,13 +202,6 @@ def _pull_cleared_field_from_hr_onboarding_tracker(updated_tracker_df: pd.DataFr
     return _update_dataframe(updated_tracker_df, hr_cleared_df)
 
 
-def _refresh_dbt() -> None:
-    dbt_conn = DbtClient()
-    logging.info("Refreshing dbt; sleeping for 30 seconds")
-    dbt_conn.run_job()
-    sleep(30)
-
-
 def _rescind_records_from_tracker(updated_tracker_df: pd.DataFrame, rescinded_offer_ids: list) -> pd.DataFrame:
     logging.info("Identified rescinded offers")
     updated_tracker_df = _update_rescinded_col(rescinded_offer_ids, updated_tracker_df)
@@ -253,7 +245,6 @@ def _update_tracker_data(tracker_backup_df: pd.DataFrame, jobvite_df: pd.DataFra
 
 
 def tracker_refresh(tech_tracker_spreadsheet: Spreadsheet, hr_spreadsheet: Spreadsheet, year: str) -> None:
-    _refresh_dbt()
     dataset = os.getenv("GBQ_DATASET")
     bq_conn = BigQueryClient()
     jobvite_df = _get_and_prep_jobvite_data(bq_conn, dataset, year)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from utils.arg_parser import create_parser
 from utils.logger_config import get_logger
 
 TECH_TRACKER_SHEET = os.getenv("TECH_TRACKER_SHEETS_ID")
-HR_MOT_SHEET = os.getenv("HR_MOT_SHEETS_ID")
+HR_TRACKER_SHEET = os.getenv("HR_TRACKER_SHEETS_ID")
 GOOGLE_CREDENTIALS = os.getenv("CREDENTIALS_FILE")
 
 # Create Parser
@@ -36,7 +36,7 @@ def _refresh_dbt() -> None:
 
 def main(notifications):
     tech_spreadsheet = create_sheet_connection(TECH_TRACKER_SHEET)
-    hr_mot_spreadsheet = create_sheet_connection(HR_MOT_SHEET)
+    hr_mot_spreadsheet = create_sheet_connection(HR_TRACKER_SHEET)
     if ARGS.sla_monitor_refresh:
         notifications.extend_job_name("- SLA Monitor Refresh")
         refresh_sla_source(tech_spreadsheet)

--- a/utils/arg_parser.py
+++ b/utils/arg_parser.py
@@ -15,5 +15,11 @@ def create_parser():
         help="Refreshes Tech's SLA monitor data source",
         action="store_true"
     )
+    parser.add_argument(
+        "--dbt-refresh",
+        dest="dbt_refresh",
+        help="Refreshes dbt before running updating tracker",
+        action="store_true"
+    )
 
     return parser


### PR DESCRIPTION
Update repo to pull in dates from the tech tracker and the dbt report model as data time objects then convert these dates to strings before pushing data into the tracker.

This differs to the previous method where dates were converted between date and string objects whenever needed. Keeping everything as date objects while processing data helps with errors.

Also included:
- Added runtime arg for dbt refresh
- Removed "mot" from code as the HR Tracker will no longer be referred to as the mot
- Re-ordered funcs in tracker_refresh alphabetical order. 
- Created new funcs to make tracker_refresh func easier to read.